### PR TITLE
change url and drop requires in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description_content_type = text/markdown
 author = Daniel Allen, Ian Bolliger, Nicholas Depsky, Junho Choi
 author_email = ian.bolliger@blackrock.com
 version = v1.0.0
-url = https://gitlab.com/ClimateImpactLab/coastal/projects/sliiders
+url = https://github.com/ClimateImpactLab/sliiders
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License
@@ -15,8 +15,4 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-requires = numpy
-           scipy
-           xarray
-           pandas
 python_requires = >=3.6


### PR DESCRIPTION
Fixes #3 and drops requires. It was an incomplete list of required packages and not really necessary as we aren't (as of right now) intending this package to be used outside of the context of helper functions for these notebooks