### PR TITLE
Removing redundant CIA WFB download code

### DIFF
--- a/notebooks/create-SLIIDERS-ECON/country_level_ypk/ypk1_prep_clean.ipynb
+++ b/notebooks/create-SLIIDERS-ECON/country_level_ypk/ypk1_prep_clean.ipynb
@@ -29,7 +29,6 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import os\n",
     "import shutil\n",
     "from operator import itemgetter\n",
     "\n",
@@ -60,7 +59,7 @@
    "outputs": [],
    "source": [
     "# creating necessary directory\n",
-    "os.makedirs(sset.DIR_YPK_INT, exist_ok=True)"
+    "sset.DIR_YPK_INT.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -252,20 +251,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## attaching country codes; first import un_pop information\n",
+    "# attaching country codes; first import un_pop information\n",
     "by_age = pd.read_csv(sset.DIR_UN_WPP_RAW / \"UN_WPP2019_Population_by_Age.csv\")\n",
     "\n",
-    "## attaching the country codes\n",
+    "# attaching the country codes\n",
     "un_df_dic = dict(zip(un_df.Location, un_df.index.get_level_values(\"ccode\")))\n",
     "by_age[\"ccode\"] = by_age.Location.map(un_df_dic)\n",
     "\n",
-    "## double checking if any are missing country codes\n",
+    "# double checking if any are missing country codes\n",
     "print(\"The missing-ccode rows are:\", by_age[pd.isnull(by_age.ccode)].shape[0])\n",
     "\n",
-    "## saving the ccodes as indices\n",
+    "# saving the ccodes as indices\n",
     "by_age.set_index([\"ccode\"], inplace=True)\n",
     "\n",
-    "## exporting\n",
+    "# exporting\n",
     "by_age.to_parquet(sset.DIR_YPK_INT / \"un_population_by_age.parquet\")"
    ]
   },
@@ -355,7 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.makedirs(sset.DIR_GEG15_INT, exist_ok=True)\n",
+    "sset.DIR_GEG15_INT.mkdir(parents=True, exist_ok=True)\n",
     "df.to_parquet(sset.DIR_GEG15_INT / \"gar_exp.parquet\")"
    ]
   },
@@ -416,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## unzipping: this may take a long time\n",
+    "# unzipping: this may take a long time\n",
     "CIA_DIR, zip_file_name = sset.DIR_YPK_RAW, \"weekly_json.7z\"\n",
     "shutil.register_unpack_format(\"7zip\", [\".7z\"], unpack_7zarchive)\n",
     "shutil.unpack_archive(CIA_DIR / zip_file_name, CIA_DIR)"
@@ -429,9 +428,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## ordering them by time (Earlier entries first)\n",
+    "# ordering them by time (Earlier entries first)\n",
     "CIA_DIR_week = sset.DIR_YPK_RAW / \"weekly_json\"\n",
-    "file_lst = np.sort(os.listdir(CIA_DIR_week))"
+    "file_lst = np.sort(list(CIA_DIR_week.glob(\"*\")))"
    ]
   },
   {
@@ -449,16 +448,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def file_gdp_fetcher(filename, location=CIA_DIR_week):\n",
+    "def file_gdp_fetcher(filename):\n",
     "    \"\"\"From weekly-scraped CIA World Factbook data (in json format), gather relevant GDP\n",
     "    information and save as a dictionary.\n",
     "\n",
     "    Parameters\n",
     "    ----------\n",
-    "    filename : str\n",
-    "        individual weekly-scraped CIA World Factbook data file name\n",
-    "    location : Path\n",
-    "        where the CIA World Factbook data are stored at\n",
+    "    filename : Path-like or str\n",
+    "        individual weekly-scraped CIA World Factbook data file path\n",
     "\n",
     "    overall_dict : dict\n",
     "        information (in dictionary format) containing the countries' GDP information\n",
@@ -466,7 +463,7 @@
     "\n",
     "    \"\"\"\n",
     "\n",
-    "    with open(location / filename) as fp:\n",
+    "    with open(filename) as fp:\n",
     "        data = json.load(fp)\n",
     "    ctries = list(data[\"countries\"].keys())\n",
     "    ctries.sort()\n",
@@ -519,7 +516,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## individual results of the file_gdp_fetcher function stored in a list\n",
+    "# individual results of the file_gdp_fetcher function stored in a list\n",
     "lst_results = []\n",
     "for f in tqdm(file_lst):\n",
     "    lst_results.append(file_gdp_fetcher(f))"
@@ -634,8 +631,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## let's use the UN populations data, since it should have the most countries\n",
-    "## to match names with values\n",
+    "# let's use the UN populations data, since it should have the most countries\n",
+    "# to match names with values\n",
     "un_loc = sset.DIR_YPK_INT\n",
     "unpop = pd.read_parquet(un_loc / \"un_population.parquet\").reset_index()\n",
     "\n",
@@ -676,17 +673,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## manual cleanup\n",
+    "# manual cleanup\n",
     "unknown_case_ccodes = [\"BHS\", \"BOL\", \"BRN\", \"MMR\", \"CPV\", \"COD\", \"COG\", \"CIV\", \"CUW\"]\n",
     "unknown_case_ccodes += [\"CZE\", \"TLS\", \"-\", \"FLK\", \"GMB\", \"-\", \"GGY\", \"GNB\", \"HKG\"]\n",
     "unknown_case_ccodes += [\"IRN\", \"JEY\", \"PRK\", \"KOR\", \"KO-\", \"LAO\", \"MAC\", \"MKD\", \"FSM\"]\n",
     "unknown_case_ccodes += [\"MDA\", \"-\", \"RUS\", \"SHN\", \"MAF\", \"SXM\", \"SWZ\", \"SYR\", \"TWN\"]\n",
     "unknown_case_ccodes += [\"TZA\", \"TLS\", \"USA\", \"VEN\", \"VNM\", \"VIR\", \"WLF\", \"-\"]\n",
     "\n",
-    "## double-checking the names' lengths\n",
+    "# double-checking the names' lengths\n",
     "print(len(unknown_case) == len(unknown_case_ccodes))\n",
     "\n",
-    "## getting a dataframe\n",
+    "# getting a dataframe\n",
     "update_df = pd.DataFrame(data={\"country\": unknown_case, \"ccode2\": unknown_case_ccodes})\n",
     "update_df.set_index([\"country\"], inplace=True)\n",
     "ctry_agg_df = ctry_agg_df.merge(\n",
@@ -724,7 +721,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## neutral assumption when conversion rates are missing\n",
+    "# neutral assumption when conversion rates are missing\n",
     "ctry_agg_df = (\n",
     "    ctry_agg_df.reset_index()\n",
     "    .set_index([\"ccode\", \"year\"])\n",
@@ -733,10 +730,10 @@
     ")\n",
     "ctry_agg_df.loc[pd.isnull(ctry_agg_df.conv), \"conv\"] = 1\n",
     "\n",
-    "## first, divide by 1000000\n",
+    "# first, divide by 1000000\n",
     "ctry_agg_df[\"gdp\"] = ctry_agg_df[\"gdp\"] / 1000000\n",
     "\n",
-    "## applying the conversion by multiplying\n",
+    "# applying the conversion by multiplying\n",
     "ctry_agg_df[\"gdp_ppp2017_currUSD\"] = ctry_agg_df[\"gdp\"] * ctry_agg_df[\"conv\"]"
    ]
   },
@@ -771,7 +768,7 @@
     "    .set_index([\"ccode\", \"year\"])\n",
     ")\n",
     "\n",
-    "## generating constant 2017 ppp\n",
+    "# generating constant 2017 ppp\n",
     "ctry_agg_df[\"gdp_constant2017ppp\"] = (\n",
     "    ctry_agg_df[\"gdp_ppp2017_currUSD\"] / ctry_agg_df[\"pl_usa\"]\n",
     ")\n",

--- a/notebooks/create-SLIIDERS-ECON/download-sliiders-econ-input-data.ipynb
+++ b/notebooks/create-SLIIDERS-ECON/download-sliiders-econ-input-data.ipynb
@@ -69,7 +69,6 @@
     "    sset.DIR_WB_WDI_RAW,\n",
     "    sset.DIR_LITPOP_RAW,\n",
     "    sset.DIR_GEG15_RAW,\n",
-    "    sset.DIR_CIA_RAW,\n",
     "    sset.DIR_CCI_RAW,\n",
     "    sset.DIR_UN_WPP_RAW,\n",
     "    sset.DIR_UN_AMA_RAW,\n",

--- a/notebooks/create-SLIIDERS-ECON/download-sliiders-econ-input-data.ipynb
+++ b/notebooks/create-SLIIDERS-ECON/download-sliiders-econ-input-data.ipynb
@@ -344,30 +344,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "446351d7-9bca-42ba-b3f3-50b7c3da4a7f",
-   "metadata": {},
-   "source": [
-    "### CIA World Factbook, versions 2000 to 2020"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "047f9b83-eee1-41ab-a5fb-a2c100434d84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cia_download_url = \"https://www.cia.gov/the-world-factbook/about/archives/download\"\n",
-    "cia_files = [f\"factbook-{x}.zip\" for x in range(2000, 2021)]\n",
-    "\n",
-    "for i in tqdm(cia_files):\n",
-    "    cia_req = requests.get(\"/\".join([cia_download_url, i]))\n",
-    "    cia_zip = ZipFile(BytesIO(cia_req.content))\n",
-    "    cia_zip.extractall(str(sset.DIR_CIA_RAW))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a9f0b8fa-7c93-4735-9caa-e07777d150a2",
    "metadata": {},
    "source": [

--- a/sliiders/settings.py
+++ b/sliiders/settings.py
@@ -623,7 +623,6 @@ PATH_COUNTRY_LEVEL_EXPOSURE_PROJ = (
     DIR_YPK_FINAL / "gdp_gdppc_pop_capital_proj_2010_2100.parquet"
 )
 
-DIR_CIA_RAW = DIR_YPK_RAW / "cia_wfb"
 DIR_UN_AMA_RAW = DIR_YPK_RAW / "un_ama" / UN_AMA_DATESTAMP
 DIR_UN_WPP_RAW = DIR_YPK_RAW / "un_wpp" / UN_WPP_VERS
 DIR_WB_WDI_RAW = DIR_YPK_RAW / "wb_wdi" / WB_WDI_DATESTAMP


### PR DESCRIPTION
This PR does the following:
- removes redundant CIA WFB download code in `notebooks/create-SLIIDERS-ECON/download-sliiders-econ-input-data.ipynb`
- removes the use of `os.makedirs` and `os.listdir` (and the import of `os` in general), updates the code to accommodate this change in `notebooks/create-SLIIDERS-ECON/country_level_ypk/ypk1_prep_clean.ipynb`